### PR TITLE
ReadSingleEvent: fixes and improvements

### DIFF
--- a/fsevents.go
+++ b/fsevents.go
@@ -466,11 +466,11 @@ func (w *Watcher) GetEventCount() uint32 {
 
 // ReadSingleEvent reads and returns a single event from the watch descriptor.
 func (w *Watcher) ReadSingleEvent() (*FsEvent, error) {
-	var buffer [unix.SizeofInotifyEvent + unix.PathMax]byte
+	var buffer [unix.SizeofInotifyEvent + unix.PathMax + 1]byte
 
 	bytesRead, err := C.read(C.int(w.InotifyDescriptor),
 		unsafe.Pointer(&buffer),
-		C.ulong(unix.SizeofInotifyEvent+unix.PathMax))
+		C.ulong(unix.SizeofInotifyEvent+unix.PathMax+1))
 
 	if bytesRead < unix.SizeofInotifyEvent {
 		return nil, ErrIncompleteRead

--- a/fsevents.go
+++ b/fsevents.go
@@ -2,9 +2,6 @@
 // filesystem events on a Linux system using the inotify kernel subsystem.
 package fsevents
 
-// #include <unistd.h>
-import "C"
-
 import (
 	"errors"
 	"fmt"
@@ -468,10 +465,7 @@ func (w *Watcher) GetEventCount() uint32 {
 func (w *Watcher) ReadSingleEvent() (*FsEvent, error) {
 	var buffer [unix.SizeofInotifyEvent + unix.PathMax + 1]byte
 
-	bytesRead, err := C.read(C.int(w.InotifyDescriptor),
-		unsafe.Pointer(&buffer),
-		C.ulong(unix.SizeofInotifyEvent+unix.PathMax+1))
-
+	bytesRead, err := unix.Read(w.InotifyDescriptor, buffer[:])
 	if bytesRead < unix.SizeofInotifyEvent {
 		return nil, ErrIncompleteRead
 	} else if err != nil {

--- a/fsevents.go
+++ b/fsevents.go
@@ -466,10 +466,11 @@ func (w *Watcher) ReadSingleEvent() (*FsEvent, error) {
 	var buffer [unix.SizeofInotifyEvent + unix.PathMax + 1]byte
 
 	bytesRead, err := unix.Read(w.InotifyDescriptor, buffer[:])
+	if err != nil {
+		return nil, fmt.Errorf("%s: %s", ErrReadError.Error(), err)
+	}
 	if bytesRead < unix.SizeofInotifyEvent {
 		return nil, ErrIncompleteRead
-	} else if err != nil {
-		return nil, fmt.Errorf("%s: %s", ErrReadError.Error(), err)
 	}
 
 	rawEvent := (*unix.InotifyEvent)(unsafe.Pointer(&buffer))


### PR DESCRIPTION
1. fix the buffer size (was 1 byte shorter than needed).
2. use `unix.Read` instead of `C.read`, drop cgo dependency.
3. fix read error handling.

Please see individual commits for more details.