### PR TITLE
Fix RecursiveAdd() is adding subdirectories twice

### DIFF
--- a/fsevents.go
+++ b/fsevents.go
@@ -363,13 +363,6 @@ func (w *Watcher) RecursiveAdd(rootPath string, mask uint32) error {
 			if err := w.RecursiveAdd(childPath, mask); err != nil {
 				return fmt.Errorf("could not add recurisve-descriptor for path %q: %s", childPath, err.Error())
 			}
-			d, err := w.AddDescriptor(childPath, mask)
-			if err != nil {
-				return fmt.Errorf("could not add descriptor for path %q: %s", childPath, err.Error())
-			}
-			if err := d.Start(); err != nil {
-				return fmt.Errorf("could not start watch for path %q: %s", childPath, err.Error())
-			}
 		}
 	}
 	return nil

--- a/fsevents_test.go
+++ b/fsevents_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"path"
 	"reflect"
 	"runtime"
 	"testing"
@@ -456,4 +457,29 @@ func TestRegisterEventHandler(t *testing.T) {
 	assert(t, (err != nil), err)
 
 	teardownDirs([]string{testRootDir})
+}
+
+func TestRecursiveAdd(t *testing.T) {
+	var w *fsevents.Watcher
+	var err error
+
+	testDirs := []string{
+		testRootDir,
+		path.Join(testRootDir, "a"),
+		path.Join(testRootDir, "a/aa"),
+		path.Join(testRootDir, "b"),
+		path.Join(testRootDir, "b/bb"),
+	}
+
+	setupDirs(testDirs)
+
+	w, err = fsevents.NewWatcher()
+	assert(t, (w != nil), fmt.Errorf("NewWatcher should have returned non-nil Watcher"))
+	assert(t, (err == nil), err)
+
+	err = w.RecursiveAdd(testRootDir, fsevents.AllEvents)
+	assert(t, (err == nil), err)
+	assert(t, (int(w.GetRunningDescriptors()) == len(testDirs)), fmt.Errorf("Count of running descriptors is not equal to number of directories"))
+
+	teardownDirs(testDirs)
 }


### PR DESCRIPTION
Assuming you have following folder structure:

    test
    test/a
    test/a/aa

RecursiveAdd("test") had thrown following error:

    could not add recurisve-descriptor for path "test/a": could not add
    descriptor for path "test/a/aa": descriptor for that directory
    already exists

The reason is that RecursiveAdd() wanted to add an descriptor for any
existing subdirectory evenso the recursive function call had done this
already.